### PR TITLE
Implement auto-complete in shell function

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,15 @@ source fish/pod_node_labels.fish
 # Or add to your Fish config
 echo "source "(pwd)"/fish/pod_node_labels.fish" >> ~/.config/fish/config.fish
 ```
+### Bash Completion
+```bash
+# Enable completion in your current session
+source bash/pod_node_labels_completion.bash
+
+# Or add to your ~/.bashrc for automatic loading
+echo "source $(pwd)/bash/pod_node_labels_completion.bash" >> ~/.bashrc
+```
+
 
 ## Available Functions
 

--- a/bash/pod_node_labels_completion.bash
+++ b/bash/pod_node_labels_completion.bash
@@ -1,0 +1,31 @@
+# Bash completion for pod node label functions
+
+# Common kubectl options to suggest
+__pod_kubectl_opts="--namespace -n --all-namespaces -A --selector -l --field-selector"
+
+_pod_node_labels_complete()
+{
+    local cur
+    cur="${COMP_WORDS[COMP_CWORD]}"
+
+    # If completing first argument of podname_to_node_label, offer node labels
+    if [[ ${COMP_CWORD} -eq 1 && ${COMP_WORDS[0]} == podname_to_node_label ]]; then
+        # Gather node labels from kubectl output
+        local labels
+        labels=$(kubectl get nodes -o json 2>/dev/null | jq -r '.items[].metadata.labels | keys[]' | sort -u)
+        # shellcheck disable=SC2207
+        COMPREPLY=( $(compgen -W "${labels}" -- "$cur") )
+        return
+    fi
+
+    # shellcheck disable=SC2207
+    COMPREPLY=( $(compgen -W "${__pod_kubectl_opts}" -- "$cur") )
+}
+
+# Register completion function for all provided functions
+complete -F _pod_node_labels_complete pod_node_labels
+complete -F _pod_node_labels_complete podname_to_node_label
+complete -F _pod_node_labels_complete podname_to_az
+complete -F _pod_node_labels_complete pod_to_instance_type
+complete -F _pod_node_labels_complete pod_to_karpenter_nodepool
+complete -F _pod_node_labels_complete pod_per_az


### PR DESCRIPTION
## Summary

Added instructions in the README for enabling bash completions by sourcing a new script, with optional .bashrc integration

Created a bash completion script that suggests node labels for the first argument of podname_to_node_label and provides common kubectl options for other arguments

## Testing
- `shellcheck bash/pod_node_labels_completion.bash`
- `bash -n bash/pod_node_labels.bash`
- `bash -n bash/pod_node_labels_completion.bash`

------
https://chatgpt.com/codex/tasks/task_e_68614e8f8d008329b50a72921245afcb